### PR TITLE
Check simulator is running and which name is being used

### DIFF
--- a/bin/reset-sim
+++ b/bin/reset-sim
@@ -5,36 +5,24 @@ def osascript(script)
 end
 
 osascript <<-END
-    tell application "iOS Simulator"
+    if application "iOS Simulator" is running then
+        set simulator_app_name to "iOS Simulator"
+    else if application "Simulator" is running then
+        set simulator_app_name to "Simulator"
+    else
+        log "Simulator must be running before it can be reset."
+        return
+    end if
+
+    tell application simulator_app_name
         activate
     end tell
 
     tell application "System Events"
-        tell process "iOS Simulator"
+        tell process simulator_app_name
             tell menu bar 1
-                tell menu bar item "iOS Simulator"
-                    tell menu "iOS Simulator"
-                        click menu item "Reset Content and Settings…"
-                    end tell
-                end tell
-            end tell
-            tell window 1
-                click button "Reset"
-            end tell
-        end tell
-    end tell
-END
-
-osascript <<-END
-    tell application "Simulator"
-        activate
-    end tell
-
-    tell application "System Events"
-        tell process "Simulator"
-            tell menu bar 1
-                tell menu bar item "Simulator"
-                    tell menu "Simulator"
+                tell menu bar item simulator_app_name
+                    tell menu simulator_app_name
                         click menu item "Reset Content and Settings…"
                     end tell
                 end tell

--- a/bin/reset-sim
+++ b/bin/reset-sim
@@ -5,31 +5,38 @@ def osascript(script)
 end
 
 osascript <<-END
-    if application "iOS Simulator" is running then
-        set simulator_app_name to "iOS Simulator"
-    else if application "Simulator" is running then
+
+    -- assume most people are on xcode7 or greater
+    -- so try that first
+    try
+        tell application "Simulator" to activate
         set simulator_app_name to "Simulator"
-    else
-        log "Simulator must be running before it can be reset."
-        return
-    end if
+    on error number -1728
+        log "Trying legacy iOS Simulator application..."
+        try
+            tell application "iOS Simulator" to activate
+            set simulator_app_name to "iOS Simulator"
+        on error number -1728
+            log "No Simulator application installed"
+            set simulator_app_name to "Nothing"
+        end try
+    end try
 
-    tell application simulator_app_name
-        activate
-    end tell
 
-    tell application "System Events"
-        tell process simulator_app_name
-            tell menu bar 1
-                tell menu bar item simulator_app_name
-                    tell menu simulator_app_name
-                        click menu item "Reset Content and Settings…"
+    if contents of simulator_app_name is not equal to "Nothing"
+        tell application "System Events"
+            tell process simulator_app_name
+                tell menu bar 1
+                    tell menu bar item simulator_app_name
+                        tell menu simulator_app_name
+                            click menu item "Reset Content and Settings…"
+                        end tell
                     end tell
                 end tell
-            end tell
-            tell window 1
-                click button "Reset"
+                tell window 1
+                    click button "Reset"
+                end tell
             end tell
         end tell
-    end tell
+    end if
 END

--- a/bin/reset-sim
+++ b/bin/reset-sim
@@ -8,6 +8,7 @@ osascript <<-END
 
     -- assume most people are on xcode7 or greater
     -- so try that first
+    set simulator_app_name to missing value
     try
         tell application "Simulator" to activate
         set simulator_app_name to "Simulator"
@@ -18,12 +19,11 @@ osascript <<-END
             set simulator_app_name to "iOS Simulator"
         on error number -1728
             log "No Simulator application installed"
-            set simulator_app_name to "Nothing"
         end try
     end try
 
 
-    if contents of simulator_app_name is not equal to "Nothing"
+    if simulator_app_name is not equal to missing value
         tell application "System Events"
             tell process simulator_app_name
                 tell menu bar 1


### PR DESCRIPTION
Checks to see which simulator is being used (Pre or post xcode7), also spits out a message if the simulator is not running.

Tested with xcode7 ("Simulator") and where the simulator is not running, but haven't tested the pre-code7 ("iOS Simulator") case.
